### PR TITLE
Update return values of eth_getTransactionByHash

### DIFF
--- a/json-rpc.md
+++ b/json-rpc.md
@@ -1170,7 +1170,7 @@ Returns the information about a transaction requested by transaction hash.
 
 ```js
 params: [
-   "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"
+   "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"
 ]
 ```
 
@@ -1178,39 +1178,45 @@ params: [
 
 `Object` - A transaction object, or `null` when no transaction was found:
 
-  - `hash`: `DATA`, 32 Bytes - hash of the transaction.
-  - `nonce`: `QUANTITY` - the number of transactions made by the sender prior to this one.
   - `blockHash`: `DATA`, 32 Bytes - hash of the block where this transaction was in. `null` when its pending.
   - `blockNumber`: `QUANTITY` - block number where this transaction was in. `null` when its pending.
-  - `transactionIndex`: `QUANTITY` - integer of the transactions index position in the block. `null` when its pending.
   - `from`: `DATA`, 20 Bytes - address of the sender.
-  - `to`: `DATA`, 20 Bytes - address of the receiver. `null` when its a contract creation transaction.
-  - `value`: `QUANTITY` - value transferred in Wei.
-  - `gasPrice`: `QUANTITY` - gas price provided by the sender in Wei.
   - `gas`: `QUANTITY` - gas provided by the sender.
+  - `gasPrice`: `QUANTITY` - gas price provided by the sender in Wei.
+  - `hash`: `DATA`, 32 Bytes - hash of the transaction.
   - `input`: `DATA` - the data send along with the transaction.
+  - `nonce`: `QUANTITY` - the number of transactions made by the sender prior to this one.
+  - `to`: `DATA`, 20 Bytes - address of the receiver. `null` when its a contract creation transaction.
+  - `transactionIndex`: `QUANTITY` - integer of the transactions index position in the block. `null` when its pending.
+  - `value`: `QUANTITY` - value transferred in Wei.
+  - `v`: `QUANTITY` - ECDSA recovery id
+  - `r`: `DATA`, 32 Bytes - ECDSA signature r
+  - `s`: `DATA`, 32 Bytes - ECDSA signature s
 
 ##### Example
 ```js
 // Request
-curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"],"id":1}'
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"],"id":1}'
 
 // Result
 {
-"id":1,
-"jsonrpc":"2.0",
-"result": {
-    "hash":"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-    "nonce":"0x",
-    "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
-    "blockNumber": "0x15df", // 5599
-    "transactionIndex":  "0x1", // 1
-    "from":"0x407d73d8a49eeb85d32cf465507dd71d507100c1",
-    "to":"0x85h43d8a49eeb85d32cf465507dd71d507100c1",
-    "value":"0x7f110", // 520464
-    "gas": "0x7f110", // 520464
-    "gasPrice":"0x09184e72a000",
-    "input":"0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360",
+  "jsonrpc":"2.0",
+  "id":1,
+  "result":{
+    "blockHash":"0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2",
+    "blockNumber":"0x5daf3b", // 6139707
+    "from":"0xa7d9ddbe1f17865597fbd27ec712455208b6b76d",
+    "gas":"0xc350", // 50000
+    "gasPrice":"0x4a817c800", // 20000000000
+    "hash":"0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b",
+    "input":"0x68656c6c6f21",
+    "nonce":"0x15", // 21
+    "to":"0xf02c1c8e6114b1dbe8937a39260b5b0a374432bb",
+    "transactionIndex":"0x41", // 65
+    "value":"0xf3dbb76162000", // 4290000000000000
+    "v":"0x25", // 37
+    "r":"0x1b5e176d927f8e9ab405058b2d2457392da3e20f328b16ddabcebc33eaac5fea",
+    "s":"0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c"
   }
 }
 ```


### PR DESCRIPTION
Transaction includes `v`, `r`, `s` from geth v1.5.0:
https://github.com/ethereum/go-ethereum/commit/b0d9f7372a04fa8f0ffc391f0997e2e062d465ef#diff-607ee6300c766df112070d851a1661c9R691

Where `RPCTransaction` is defined:
https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L860