### PR TITLE
add deprecation notice in advance of archiving repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Eth.wiki is a now largely outdated collection of resources explaining the state-of-the-art in Ethereum circa 2020.
 
-The material in this repository has been updated and migrated to http://ethereum.org.
+The material in this repository has been updated and migrated to ethereum.org.
 
-This repository is due to be archived shortly. Please visit http://ethereum.org instead for current Ethereum information!
+This repository is due to be archived shortly. Please visit ethereum.org instead for current Ethereum information!
 
+Looking to contribute to Ethereum documentation? Check out the ethereum.org repo: https://github.com/ethereum/ethereum-org-website

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Eth.wiki
+
+:no_entry_sign: **no longer actively maintained** :no_entry_sign:
+
+Eth.wiki is a now largely outdated collection of resources explaining the state-of-the-art in Ethereum circa 2020.
+
+The material in this repository has been updated and migrated to ethereum.org.
+
+This repository is due to be archived shortly. Please visit ethereum.org instead!
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Eth.wiki is a now largely outdated collection of resources explaining the state-of-the-art in Ethereum circa 2020.
 
-The material in this repository has been updated and migrated to ethereum.org.
+The material in this repository has been updated and migrated to http://ethereum.org.
 
-This repository is due to be archived shortly. Please visit ethereum.org instead!
+This repository is due to be archived shortly. Please visit http://ethereum.org instead for current Ethereum information!
 


### PR DESCRIPTION
The relevant material from eth.wiki has been migrated over to [ethereum.org](http://ethereum.org), enabling the wiki to be sunsetted without losing the valuable information it contains. This PR simply adds a README with a short deprecation notice alerting readers to the imminent deprecation of eth.wiki.

Relates to issue 5690 in ethereum.org repo [here](https://github.com/ethereum/ethereum-org-website/issues/5690)